### PR TITLE
Open URLs in user's default browser instead of Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ## Overview
 An extension for ulauncher app for **linux**. 
 - Lets you open urls directly inside ulauncher
-- **You need chrome installed in your device for this extension!**
+- ~~**You need chrome installed in your device for this extension!**~~
+- The extension can now open URLs in your default browser.
 
 ## Examples
 - ```open youtube```

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ class KeywordQueryEventListener(EventListener):
             ExtensionResultItem(
                 icon='images/icon.png',
                 name= f"Open in browser",
-                description= f"Open url {url_opener.complete_url(event.get_argument())} in chrome",
+                description= f"Open url {url_opener.complete_url(event.get_argument())} {webbrowser.get().name}",
                 on_enter=ExtensionCustomAction({"url":event.get_argument()}, keep_app_open=False))
         ]
 

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ class KeywordQueryEventListener(EventListener):
             ExtensionResultItem(
                 icon='images/icon.png',
                 name= f"Open in browser",
-                description= f"Open url {url_opener.complete_url(event.get_argument())} {webbrowser.get().name}",
+                description= f"Open url {url_opener.complete_url(event.get_argument())} in {webbrowser.get().name}",
                 on_enter=ExtensionCustomAction({"url":event.get_argument()}, keep_app_open=False))
         ]
 

--- a/main.py
+++ b/main.py
@@ -10,12 +10,9 @@ from ulauncher.api.shared.action.HideWindowAction import HideWindowAction
 import webbrowser
 
 class UrlOpener:
-    def __init__(self):
-        webbrowser.register('chrome', None, webbrowser.BackgroundBrowser('/usr/bin/google-chrome'))
-        
     def open(self, url):
         url = self.complete_url(url)
-        webbrowser.get('chrome').open(url)
+        webbrowser.open(url)
             
     def complete_url(self, url):
         if url == None:

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
       "id": "demo_kw",
       "type": "keyword",
       "name": "URL",
-      "default_value": "openss"
+      "default_value": "open"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
       "id": "demo_kw",
       "type": "keyword",
       "name": "URL",
-      "default_value": "open"
+      "default_value": "openss"
     }
   ]
 }


### PR DESCRIPTION
### What Changed
- Removed hardcoded dependency on Google Chrome.
- Updated `UrlOpener` to use `webbrowser.open()` function.
- Ensures URLs now open in the system's default web browser, improving flexibility and cross-browser support.

### Why It Matters
Previously, the extension required Google Chrome to be installed, limiting usability for users who prefer Firefox, Brave, etc. This update makes the extension browser-agnostic and more user-friendly.

### Notes
- Removed `webbrowser.register()` with Chrome path.
- Verified that `webbrowser.open()` respects system browser defaults.
